### PR TITLE
Fixed Crash on Safari

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,4 +1,12 @@
 
+layers = {
+  BG1 : 0,
+  BG2 : 0,
+  FG1 : 0,
+  FG2 : 0,
+  UI : 0
+};
+
 player = [0,0,0,0];
 
 renderTime = [10,0,100,0];
@@ -302,7 +310,7 @@ window.addEventListener("gamepadconnected", function(e) {
     e.gamepad.index, e.gamepad.id,
     e.gamepad.buttons.length, e.gamepad.axes.length);
 });
-console.log(navigator.getGamepads());
+if(navigator.getGamepads) console.log(navigator.getGamepads());
 
 function matchTimerTick(){
   matchTimer -= 0.016667;
@@ -332,7 +340,7 @@ function percentShake(kb,i){
 }
 
 function findPlayers(){
-  var gps = navigator.getGamepads();
+  var gps = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
   /*if (typeof gps != "undefined"){
     console.log(gps);
   }*/
@@ -360,7 +368,7 @@ function findPlayers(){
     }
   }
   for (var i=0;i<gps.length;i++){
-    var gamepad = navigator.getGamepads()[i];
+    var gamepad = navigator.getGamepads ? navigator.getGamepads()[i] : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : null);
     if (typeof gamepad != "undefined" &&  gamepad != null){
       var gType = 0;
       if (gamepad.id[0] == "v" || gamepad.id[0] == "1"){
@@ -950,13 +958,6 @@ fg2 = 0;
 ui = 0;
 c = 0;
 canvasMain = 0;
-layers = {
-  BG1 : 0,
-  BG2 : 0,
-  FG1 : 0,
-  FG2 : 0,
-  UI : 0
-};
 layerSwitches = {
   BG1 : true,
   BG2 : true,


### PR DESCRIPTION
On certain versions of Safari, for some strange reason, the variable layers cannot be found. This can be solved by moving the variable to the top of the file. In addition, some versions of Safari do not support gamepads, and the game crashes, as it cannot find the function navigator.getGamePads(). This can be solved by verifying that the function exists before calling it.