### PR TITLE
Fix for controllers with missing buttons or axes

### DIFF
--- a/src/main/input.js
+++ b/src/main/input.js
@@ -6,27 +6,27 @@ import {
 } from "main/linAlg";
 
 export const button = {
-  a: 0,
-  b: 1,
-  x: 2,
-  y: 3,
-  z: 4,
-  r: 5,
-  l: 6,
-  s: 7, // start
-  du: 8, // d-pad up
-  dr: 9, // d-pad right
-  dd: 10, // d-pad down
-  dl: 11 // d-pad left
+  "a" : 0, 
+  "b" : 1,
+  "x" : 2,
+  "y" : 3,
+  "z" : 4,
+  "r" : 5,
+  "l" : 6,
+  "s" : 7,  // start
+  "du": 8,  // d-pad up
+  "dr": 9,  // d-pad right
+  "dd": 10, // d-pad down
+  "dl": 11  // d-pad left
 }
 
 export const axis = {
-  lsX: 12, // left analog stick left/right
-  lsY: 13, // left analog stick up/down
-  csX: 14, // c-stick left/right
-  csY: 15, // c-stick up/down
-  lA: 16, // L button analog sensor
-  rA: 17 // R button analog sensor
+  "lsX": 12, // left analog stick left/right
+  "lsY": 13, // left analog stick up/down
+  "csX": 14, // c-stick left/right
+  "csY": 15, // c-stick up/down
+  "lA" : 16, // L button analog sensor
+  "rA" : 17  // R button analog sensor
 };
 
 export const keyboardMap = [
@@ -50,6 +50,30 @@ const raphnetV3_2Map = [0, 1, 7, 8, 2, 5, 4, 3, 10, 13, 11, 12, 0, 1, 3, 4, 5, 2
 
 export const controllerMaps = [mayflashMap, vJoyMap, raphnetV2_9Map, xbox360Map, tigergameMap, retrolinkMap, raphnetV3_2Map];
 
+
+// Checking gamepad inputs are in allowable range
+
+export function gpdaxis ( gpd, gpdID, ax ) { // gpd.axes[n] but checking axis index is in range
+  let number = controllerMaps[gpdID][axis[ax]];
+  if (number > gpd.axes.length) {
+   return 0;
+  }
+  else {
+    return gpd.axes[number];
+  }
+};
+
+export function gpdbutton ( gpd, gpdID, but ) { // gpd.buttons[n] but checking button index is in range
+  let number = controllerMaps[gpdID][button[but]];
+  if (number > gpd.buttons.length) {
+    return 0;
+  }
+  else {
+    return gpd.buttons[number];
+  }
+};
+
+
 const customCenters = function() {
   this.ls = new Vec2D(0, 0);
   this.cs = new Vec2D(0, 0);
@@ -58,20 +82,6 @@ const customCenters = function() {
 };
 
 export const custcent = [new customCenters, new customCenters, new customCenters, new customCenters];
-
-
-export function checkAllInputs ( gamepad, gamepadIDNumber ) {
-    for (var but in button) {
-      if (gamepad.buttons[controllerMaps[gamepadIDNumber][button.but]] == "null" ) {
-        gamepad.buttons[controllerMaps[gamepadIDNumber][button.but]] = false;
-      }
-    }
-    for (var ax in axis) {
-      if (gamepad.axes[controllerMaps[gamepadIDNumber][axis.ax]] == "null" ) {
-        gamepad.axes[controllerMaps[gamepadIDNumber][axis.ax]] = 0;
-      }
-    }
-};    
 
 
 //--CONTROLLER IDs-------------------------------------

--- a/src/main/input.js
+++ b/src/main/input.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/*eslint-disable*/
 
 import {
   inverseMatrix,
@@ -17,7 +17,10 @@ export const button = {
   du: 8, // d-pad up
   dr: 9, // d-pad right
   dd: 10, // d-pad down
-  dl: 11, // d-pad left
+  dl: 11 // d-pad left
+}
+
+export const axis = {
   lsX: 12, // left analog stick left/right
   lsY: 13, // left analog stick up/down
   csX: 14, // c-stick left/right
@@ -55,6 +58,20 @@ const customCenters = function() {
 };
 
 export const custcent = [new customCenters, new customCenters, new customCenters, new customCenters];
+
+
+export function checkAllInputs ( gamepad, gamepadIDNumber ) {
+    for (var but in button) {
+      if (gamepad.buttons[controllerMaps[gamepadIDNumber][button.but]] == "null" ) {
+        gamepad.buttons[controllerMaps[gamepadIDNumber][button.but]] = false;
+      }
+    }
+    for (var ax in axis) {
+      if (gamepad.axes[controllerMaps[gamepadIDNumber][axis.ax]] == "null" ) {
+        gamepad.axes[controllerMaps[gamepadIDNumber][axis.ax]] = 0;
+      }
+    }
+};    
 
 
 //--CONTROLLER IDs-------------------------------------
@@ -110,15 +127,15 @@ controllerIDMap.set("289b-001d", 6);
     
 
 export function controllerNameFromIDnumber(number) {
-  if (number == 0) {
+  if (number === 0) {
     return "Mayflash Wii-U adapter";
-  } else if (number == 1) {
+  } else if (number === 1) {
     return "vJoy";
   } else if (number == 2) {
     return "raphnet v2.9 N64 adapter";
   } else if (number == 3) {
     return "XBOX 360 compatible controller";
-  } else if (number == 4) {
+  } else if (number === 4) {
     return "TigerGame 3-in-1";
   } else if (number == 5) {
     return "Retrolink adapter";

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2,11 +2,13 @@
 
 import {
   button,
+  axis,
   keyboardMap,
   controllerMaps,
   custcent,
   controllerNameFromIDnumber,
   controllerIDNumberFromGamepadID,
+  checkAllInputs,
   scaleToGCAxis,
   scaleToGCTrigger
 } from "main/input";
@@ -666,28 +668,29 @@ window.interpretInputs = function(i, active) {
   } else {
     var gamepad = navigator.getGamepads()[currentPlayers[i]];
     //console.log(gamepad.axes);
+    checkAllInputs(gamepad, mType[i]); // sets to 0 all buttons not detected on the controller
 
-    var lstickX = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][button.lsX]], -custcent[i].ls.x, true);
-    var lstickY = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][button.lsY]], -custcent[i].ls.y, true ) * -1; // need to flip up/down
-    player[i].inputs.rawlStickAxis[0].x = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][button.lsX]], -custcent[i].ls.x, false);     // no deadzones
-    player[i].inputs.rawlStickAxis[0].y = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][button.lsY]], -custcent[i].ls.y, false) * -1;
-    var cstickX = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][button.csX]], -custcent[i].cs.x, true);
-    var cstickY = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][button.csY]], -custcent[i].cs.y, true) * -1; // need to flip up/down
+    var lstickX = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][axis.lsX]], -custcent[i].ls.x, true);
+    var lstickY = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][axis.lsY]], -custcent[i].ls.y, true ) * -1; // need to flip up/down
+    player[i].inputs.rawlStickAxis[0].x = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][axis.lsX]], -custcent[i].ls.x, false);     // no deadzones
+    player[i].inputs.rawlStickAxis[0].y = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][axis.lsY]], -custcent[i].ls.y, false) * -1;
+    var cstickX = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][axis.csX]], -custcent[i].cs.x, true);
+    var cstickY = scaleToGCAxis (gamepad.axes[controllerMaps[mType[i]][axis.csY]], -custcent[i].cs.y, true) * -1; // need to flip up/down
     if (mType[i] == 3){
       //console.log(gamepad.buttons[map.rA[mType[i]]]);
       //-custcent[i].l
       //-custcent[i].r
       // FOR XBOX CONTROLLERS
-      var lAnalog = scaleToGCTrigger(gamepad.buttons[controllerMaps[mType[i]][button.lA]].value, 0.2-custcent[i].l, 1); // shifted by +0.2
-      var rAnalog = scaleToGCTrigger(gamepad.buttons[controllerMaps[mType[i]][button.rA]].value, 0.2-custcent[i].r, 1); // shifted by +0.2
+      var lAnalog = scaleToGCTrigger(gamepad.buttons[controllerMaps[mType[i]][axis.lA]].value, 0.2-custcent[i].l, 1); // shifted by +0.2
+      var rAnalog = scaleToGCTrigger(gamepad.buttons[controllerMaps[mType[i]][axis.rA]].value, 0.2-custcent[i].r, 1); // shifted by +0.2
     }
     else if (mType[i] == 2){
-      var lAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][button.lA]],0.867-custcent[i].l, -1); // shifted by +0.867, flipped
-      var rAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][button.rA]],0.867-custcent[i].r, -1); // shifted by +0.867, flipped
+      var lAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][axis.lA]],0.867-custcent[i].l, -1); // shifted by +0.867, flipped
+      var rAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][axis.rA]],0.867-custcent[i].r, -1); // shifted by +0.867, flipped
     }
     else {
-      var lAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][button.lA]],0.867-custcent[i].l, 1); // shifted by +0.867
-      var rAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][button.rA]],0.867-custcent[i].r, 1); // shifted by +0.867
+      var lAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][axis.lA]],0.867-custcent[i].l, 1); // shifted by +0.867
+      var rAnalog = scaleToGCTrigger(gamepad.axes[controllerMaps[mType[i]][axis.rA]],0.867-custcent[i].r, 1); // shifted by +0.867
     }
   }
 
@@ -864,12 +867,12 @@ window.interpretInputs = function(i, active) {
           //custcent[i].cs = new Vec2D(gamepad.axes[5],gamepad.axes[2]*-1);
           //custcent[i].l = gamepad.axes[3]+0.8;
           //custcent[i].r = gamepad.axes[4]+0.8;
-          custcent[i].ls = new Vec2D(gamepad.axes[controllerMaps[mType[i]][button.lsX]], gamepad.axes[controllerMaps[
-            mType[i]][button.lsY]] * -1);
-          custcent[i].cs = new Vec2D(gamepad.axes[controllerMaps[mType[i]][button.csX]], gamepad.axes[controllerMaps[
-            mType[i]][button.csY]] * -1);
-          custcent[i].l = gamepad.axes[controllerMaps[mType[i]][button.lA]] + 0.8;
-          custcent[i].r = gamepad.axes[controllerMaps[mType[i]][button.rA]] + 0.8;
+          custcent[i].ls = new Vec2D(gamepad.axes[controllerMaps[mType[i]][axis.lsX]], gamepad.axes[controllerMaps[
+            mType[i]][axis.lsY]] * -1);
+          custcent[i].cs = new Vec2D(gamepad.axes[controllerMaps[mType[i]][axis.csX]], gamepad.axes[controllerMaps[
+            mType[i]][axis.csY]] * -1);
+          custcent[i].l = gamepad.axes[controllerMaps[mType[i]][axis.lA]] + 0.8;
+          custcent[i].r = gamepad.axes[controllerMaps[mType[i]][axis.rA]] + 0.8;
           console.log("Controller Reset!");
           $("#resetIndicator" + i).fadeIn(100);
           $("#resetIndicator" + i).fadeOut(500);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -620,6 +620,12 @@ window.removePlayer = function(i){
 }*/
 
 window.interpretInputs = function(i, active) {
+  function axisData (gpd, ax) {
+    return gpdaxis ( gpd, mType[i], ax );
+  };
+  function buttonData (gpd, but) {
+    return gpdbutton (gpd, mType[i], but);
+  };
 
   if (mType[i] == 10) {
     // keyboard controls
@@ -670,35 +676,28 @@ window.interpretInputs = function(i, active) {
   } else {
     var gamepad = navigator.getGamepads()[currentPlayers[i]];
     //console.log(gamepad.axes);
-
-    function axisData (ax) {
-      return gpdaxis ( gamepad, mType[i], ax );
-    };
-    function buttonData (but) {
-      return gpdbutton (gamepad, mType[i], but);
-    };
     
-    var lstickX = scaleToGCAxis (axisData("lsX"), -custcent[i].ls.x, true);
-    var lstickY = scaleToGCAxis (axisData("lsY"), -custcent[i].ls.y, true ) * -1; // need to flip up/down
-    player[i].inputs.rawlStickAxis[0].x = scaleToGCAxis (axisData("lsX"), -custcent[i].ls.x, false);     // no deadzones
-    player[i].inputs.rawlStickAxis[0].y = scaleToGCAxis (axisData("lsY"), -custcent[i].ls.y, false) * -1;
-    var cstickX = scaleToGCAxis (axisData("csX"), -custcent[i].cs.x, true);
-    var cstickY = scaleToGCAxis (axisData("csX"), -custcent[i].cs.y, true) * -1; // need to flip up/down
+    var lstickX = scaleToGCAxis (axisData(gamepad,"lsX"), -custcent[i].ls.x, true);
+    var lstickY = scaleToGCAxis (axisData(gamepad,"lsY"), -custcent[i].ls.y, true ) * -1; // need to flip up/down
+    player[i].inputs.rawlStickAxis[0].x = scaleToGCAxis (axisData(gamepad,"lsX"), -custcent[i].ls.x, false);     // no deadzones
+    player[i].inputs.rawlStickAxis[0].y = scaleToGCAxis (axisData(gamepad,"lsY"), -custcent[i].ls.y, false) * -1;
+    var cstickX = scaleToGCAxis (axisData(gamepad,"csX"), -custcent[i].cs.x, true);
+    var cstickY = scaleToGCAxis (axisData(gamepad,"csX"), -custcent[i].cs.y, true) * -1; // need to flip up/down
     if (mType[i] == 3){
       //console.log(gamepad.buttons[map.rA[mType[i]]]);
       //-custcent[i].l
       //-custcent[i].r
       // FOR XBOX CONTROLLERS
-      var lAnalog = scaleToGCTrigger(axisData("lA").value, 0.2-custcent[i].l, 1); // shifted by +0.2
-      var rAnalog = scaleToGCTrigger(axisData("rA").value, 0.2-custcent[i].r, 1); // shifted by +0.2
+      var lAnalog = scaleToGCTrigger(axisData(gamepad,"lA").value, 0.2-custcent[i].l, 1); // shifted by +0.2
+      var rAnalog = scaleToGCTrigger(axisData(gamepad,"rA").value, 0.2-custcent[i].r, 1); // shifted by +0.2
     }
     else if (mType[i] == 2){
-      var lAnalog = scaleToGCTrigger(axisData("lA"),0.867-custcent[i].l, -1); // shifted by +0.867, flipped
-      var rAnalog = scaleToGCTrigger(axisData("rA"),0.867-custcent[i].r, -1); // shifted by +0.867, flipped
+      var lAnalog = scaleToGCTrigger(axisData(gamepad,"lA"),0.867-custcent[i].l, -1); // shifted by +0.867, flipped
+      var rAnalog = scaleToGCTrigger(axisData(gamepad,"rA"),0.867-custcent[i].r, -1); // shifted by +0.867, flipped
     }
     else {
-      var lAnalog = scaleToGCTrigger(axisData("lA"),0.867-custcent[i].l, 1); // shifted by +0.867
-      var rAnalog = scaleToGCTrigger(axisData("rA"),0.867-custcent[i].r, 1); // shifted by +0.867
+      var lAnalog = scaleToGCTrigger(axisData(gamepad,"lA"),0.867-custcent[i].l, 1); // shifted by +0.867
+      var rAnalog = scaleToGCTrigger(axisData(gamepad,"rA"),0.867-custcent[i].r, 1); // shifted by +0.867
     }
   }
 
@@ -718,19 +717,12 @@ window.interpretInputs = function(i, active) {
     }
   } else {
   
-    // unfortunately the following two functions have to be called again, fix pending
-    function axisData (ax) {
-      return gpdaxis ( gamepad, mType[i], ax );
-    };
-    function buttonData (but) {
-      return gpdbutton (gamepad, mType[i], but);
-    };
-    if (buttonData("s").pressed || buttonData("du").pressed && gameMode == 5) {
+    if (buttonData(gamepad,"s").pressed || buttonData(gamepad,"du").pressed && gameMode == 5) {
       pause[i][0] = true;
     } else {
       pause[i][0] = false
     }
-    if (buttonData("z").pressed) {
+    if (buttonData(gamepad,"z").pressed) {
       frameAdvance[i][0] = true;
     } else {
       frameAdvance[i][0] = false
@@ -779,43 +771,36 @@ window.interpretInputs = function(i, active) {
       player[i].inputs.dpadright[0] = keys[keyMap.dr[0]];
       player[i].inputs.dpadup[0] = keys[keyMap.du[0]];
     } else {
-      // unfortunately the following function has to be called again
-      function buttonData (but) {
-        return gpdbutton (gamepad, mType[i], but);
-      };
-      player[i].inputs.s[0] = buttonData("s").pressed;
-      player[i].inputs.x[0] = buttonData("x").pressed;
-      player[i].inputs.a[0] = buttonData("a").pressed;
-      player[i].inputs.b[0] = buttonData("b").pressed;
-      player[i].inputs.y[0] = buttonData("y").pressed;
+
+      player[i].inputs.s[0] = buttonData(gamepad,"s").pressed;
+      player[i].inputs.x[0] = buttonData(gamepad,"x").pressed;
+      player[i].inputs.a[0] = buttonData(gamepad,"a").pressed;
+      player[i].inputs.b[0] = buttonData(gamepad,"b").pressed;
+      player[i].inputs.y[0] = buttonData(gamepad,"y").pressed;
       if (mType[i] == 3) {
         // FOR XBOX CONTROLLERS
-        player[i].inputs.r[0] = buttonData("r").value == 1 ? true : false;
-        player[i].inputs.l[0] = buttonData("l").value == 1 ? true : false;
+        player[i].inputs.r[0] = buttonData(gamepad,"r").value == 1 ? true : false;
+        player[i].inputs.l[0] = buttonData(gamepad,"l").value == 1 ? true : false;
 
         // 4 is lB, 5 is RB
         if (gamepad.buttons[4].pressed) {
           player[i].inputs.l[0] = true;
         }
       } else {
-        player[i].inputs.r[0] = buttonData("r").pressed;
-        player[i].inputs.l[0] = buttonData("l").pressed;
+        player[i].inputs.r[0] = buttonData(gamepad,"r").pressed;
+        player[i].inputs.l[0] = buttonData(gamepad,"l").pressed;
       }
-      player[i].inputs.dpadleft[0]  = buttonData("dl").pressed;
-      player[i].inputs.dpaddown[0]  = buttonData("dd").pressed;
-      player[i].inputs.dpadright[0] = buttonData("dr").pressed;
-      player[i].inputs.dpadup[0]    = buttonData("du").pressed;
+      player[i].inputs.dpadleft[0]  = buttonData(gamepad,"dl").pressed;
+      player[i].inputs.dpaddown[0]  = buttonData(gamepad,"dd").pressed;
+      player[i].inputs.dpadright[0] = buttonData(gamepad,"dr").pressed;
+      player[i].inputs.dpadup[0]    = buttonData(gamepad,"du").pressed;
     }
 
     if (!frameByFrame) {
       if (mType[i] == 10) {
         player[i].inputs.z[0] = keys[keyMap.z[0]] || keys[keyMap.z[1]];
       } else {
-        // and called again...
-        function buttonData (but) {
-          return gpdbutton (gamepad, mType[i], but);
-        };
-        player[i].inputs.z[0] = buttonData("z").pressed;
+        player[i].inputs.z[0] = buttonData(gamepad,"z").pressed;
       }
       if (player[i].inputs.z[0]) {
         player[i].inputs.lAnalog[0] = 0.35;
@@ -839,21 +824,17 @@ window.interpretInputs = function(i, active) {
         }
       }
     } else {
-      // and yet again...
-      function buttonData (but) {
-        return gpdbutton (gamepad, mType[i], but);
-      };
       if (mType[i] == 3) {
-        if (buttonData("a").pressed && buttonData("l").value == 1 && buttonData("r").value == 1 && buttonData("s").pressed) {
-          if (buttonData("b").pressed) {
+        if (buttonData(gamepad,"a").pressed && buttonData(gamepad,"l").value == 1 && buttonData(gamepad,"r").value == 1 && buttonData(gamepad,"s").pressed) {
+          if (buttonData(gamepad,"b").pressed) {
             startGame();
           } else {
             endGame();
           }
         }
       } else {
-        if (buttonData("a").pressed && buttonData("l").pressed && buttonData("r").pressed && buttonData("s").pressed) {
-          if (buttonData("b").pressed) {
+        if (buttonData(gamepad,"a").pressed && buttonData(gamepad,"l").pressed && buttonData(gamepad,"r").pressed && buttonData(gamepad,"s").pressed) {
+          if (buttonData(gamepad,"b").pressed) {
             startGame();
           } else {
             endGame();
@@ -875,21 +856,14 @@ window.interpretInputs = function(i, active) {
     player[i].showHitbox ^= true;
   }
   if (mType[i] != 10) {
-    // and again...
-      function axisData (ax) {
-        return gpdaxis ( gamepad, mType[i], ax );
-      };
-      function buttonData (but) {
-        return gpdbutton (gamepad, mType[i], but);
-      };
-    if ((buttonData("z").pressed || buttonData("du").pressed) && buttonData("x").pressed && buttonData("y").pressed && !attemptingControllerReset[i]) {
+    if ((buttonData(gamepad,"z").pressed || buttonData(gamepad,"du").pressed) && buttonData(gamepad,"x").pressed && buttonData(gamepad,"y").pressed && !attemptingControllerReset[i]) {
       attemptingControllerReset[i] = true;
       setTimeout(function() {
-        if (buttonData("du").pressed && buttonData("x").pressed && buttonData("y").pressed) {
-          custcent[i].ls = new Vec2D(axisData("lsX"), axisData("lsY") * -1);
-          custcent[i].cs = new Vec2D(axisData("lsX"), axisData("lsY") * -1);
-          custcent[i].l = axisData("lA") + 0.8;
-          custcent[i].r = axisData("RA") + 0.8;
+        if (buttonData(gamepad,"du").pressed && buttonData(gamepad,"x").pressed && buttonData(gamepad,"y").pressed) {
+          custcent[i].ls = new Vec2D(axisData(gamepad,"lsX"), axisData(gamepad,"lsY") * -1);
+          custcent[i].cs = new Vec2D(axisData(gamepad,"lsX"), axisData(gamepad,"lsY") * -1);
+          custcent[i].l = axisData(gamepad,"lA") + 0.8;
+          custcent[i].r = axisData(gamepad,"RA") + 0.8;
           console.log("Controller Reset!");
           $("#resetIndicator" + i).fadeIn(100);
           $("#resetIndicator" + i).fadeOut(500);


### PR DESCRIPTION
@schmooblidon Please check that these changes allow controllers with missing buttons/axes to work.

Note that the syntax for gamepad input now takes the following form:

- `axisData(gamepad,"lsX")` to get left/right position of left analog stick of `gamepad`
- `buttonData(gamepad,"dl")` to get d-pad left input data of `gamepad`


-------------------------------------------------------------------
If you manage to clean up the logic in the `interpretInputs` function, a lot of this can be simplified. One suggestion was to try to make the code work by having `let gamepad = ...` instead of `var gamepad = ...`, i.e. not relying on `gamepad` having scope outside of the `else` block where it is defined.
