### PR TITLE
Added Linux GC controller support

### DIFF
--- a/dist/meleelightikd.html
+++ b/dist/meleelightikd.html
@@ -93,7 +93,7 @@
         </div>
         <div class="controllerBox">
           <div class="controllerName"><p>Official Nintendo Wii U</p></div>
-          <div class="controllerDriver"><p><span class="driver"><a href="http://m4sv.com/page/wii-u-gcn-usb-driver">vJoy Driver</a></span></p></div>
+          <div class="controllerDriver"><p><span class="driver"><a href="http://m4sv.com/page/wii-u-gcn-usb-driver">Windows</a></span> <span class="driver"><a href="https://github.com/ToadKing/wii-u-gc-adapter">Linux</a></span></p></div>
           <div class="controllerBrowser">
             <div class="browserBox">
               <div class="browserImg"><img class="browserImgFile" src="assets/browser-icons/chrome.png"/></div>
@@ -123,7 +123,7 @@
             </div><!--
             --><div class="osBox osBoxShort">
               <div class="osName osNameShort"><p>Linux</p></div>
-              <div Class="osSupport"><p><span class="unknown">?</span></p></div>
+              <div Class="osSupport"><p><span class="tick">✔</span></p></div>
             </div>
           </div>
         </div>

--- a/src/main/input.js
+++ b/src/main/input.js
@@ -52,11 +52,12 @@ const raphnetV3_2Map = [ 0, 1, 7, 8, 2, 5 , 4 , 3, 10, 13, 11, 12,  0,   1,   3,
 const brookMap       = [ 0, 1, 2, 3, 4, 10, 11, 8, 12, 15, 13, 14,  0,   1,   2,   5,  3,  4  ]; // ID 7, Brook adapter (d-pad values might be wrong, user had broken d-pad)
 const ps4Map         = [ 1, 0, 2, 3, 5, 7 , 6 , 9, 12, 15, 13, 14,  0,   1,   2,   5,  3,  4  ]; // ID 8, PS4 controller
 const rockx360Map    = [ 0, 1, 2, 3, 5, 4 , 4 , 7, 12, 15, 13, 14,  0,   1,   3,   4,  2,  5  ]; // ID 9, Rock Candy Xbox 360 controller (d-pad are axes not buttons; axes to be confirmed)
-                    //   a  b  x  y  z  r   l   s  du  dr  dd  dl  lsX  lsY  csX  csY  lA  rA
 // ID number 10 reserved for keyboard
+const wiiULinuxMap   = [ 0, 3, 1, 2, 6, 5 , 4 , 7, 8 , 11, 9 , 10,  0,   1,   3,   4,  2,  5  ]; // ID 10, Official Wii U GC Adapter using wii-u-gc-adapter on Linux
+                    //   a  b  x  y  z  r   l   s  du  dr  dd  dl  lsX  lsY  csX  csY  lA  rA
 
 
-export const controllerMaps = [mayflashMap, vJoyMap, raphnetV2_9Map, xbox360Map, tigergameMap, retrolinkMap, raphnetV3_2Map, brookMap, ps4Map, rockx360Map];
+export const controllerMaps = [mayflashMap, vJoyMap, raphnetV2_9Map, xbox360Map, tigergameMap, retrolinkMap, raphnetV3_2Map, brookMap, ps4Map, rockx360Map, null, wiiULinuxMap];
 
 // Checking gamepad inputs are well defined
 export function gpdaxis ( gpd, gpdID, ax ) { // gpd.axes[n] but checking axis index is in range
@@ -173,6 +174,9 @@ controllerIDMap.set("Performance Designed Products Rock Candy Gamepad for Xbox 3
 controllerIDMap.set("0e6f-011f", 8);
 controllerIDMap.set("e6f-11f", 8);
 
+// ID 10, wii-u-gc-adapter on Linux
+controllerIDMap.set("0000-0000-Wii U GameCube Adapter", 11);
+
 //--END OF CONTROLLER IDs-------------------------------------
     
 
@@ -207,6 +211,9 @@ export function controllerNameFromIDnumber(number) {
       break;
     case 9:
       return "Xbox 360 (Rock Candy) controller";
+      break;
+    case 11:
+      return "Linux wii-u-gc-adapter";
       break;
     default:
       return "error: controller detected but not supported";

--- a/src/main/loadscreen.js
+++ b/src/main/loadscreen.js
@@ -1,13 +1,13 @@
 let scriptsLoaded = 0;
 const scripts = [{
-  // path: "./js/main.js",
-  path: "https://raw.githubusercontent.com/schmooblidon/meleelight/download/js/main.js",
+  path: "./js/main.js",
+  //path: "https://raw.githubusercontent.com/schmooblidon/meleelight/download/js/main.js",
   text: "core code",
   size: 1.8 * 1024 * 1024,
   loaded: 0,
 }, {
-  // path: "./js/animations.js",
-  path: "https://raw.githubusercontent.com/schmooblidon/meleelight/download/js/animations.js",
+  path: "./js/animations.js",
+  //path: "https://raw.githubusercontent.com/schmooblidon/meleelight/download/js/animations.js",
   text: "animations",
   size: 17.2 * 1024 * 1024,
   loaded: 0,


### PR DESCRIPTION
Support for the official Nintendo Wii U Gamecube adapter on Linux has been added. In order to get it working, users must also be using [this tool](https://github.com/ToadKing/wii-u-gc-adapter) to connect the Gamecube controllers as joysticks. A link to download this tool has been added to the controllers popup alongside the link to the Windows vJoy driver. This has been tested and is working with multiple connected controllers.

EDIT: Works on Firefox but does not work on Chrome